### PR TITLE
Fix URL in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,5 @@ seven-languages-xtext
 Seven Languages in Seven Weeks (with Xtext)
 
 This is an example project of Xtext (http://xtext.org). 
-Go to http://www.eclipse.org/Xtext/7languages.html for more.
+Go to https://www.eclipse.org/Xtext/documentation for more.
 


### PR DESCRIPTION
The README refers to an old URL that does not exist anymore