### PR TITLE
Fix: Creates new launchconfiguration on every execution

### DIFF
--- a/languages/org.xtext.builddsl.ui/src/org/xtext/builddsl/ui/launch/BuildDSLLaunchShortcut.xtend
+++ b/languages/org.xtext.builddsl.ui/src/org/xtext/builddsl/ui/launch/BuildDSLLaunchShortcut.xtend
@@ -119,7 +119,7 @@ class BuildDSLLaunchShortcut implements ILaunchShortcut {
 
 	def configEquals(ILaunchConfiguration a) {
 		a.getAttribute(ATTR_MAIN_TYPE_NAME, "X") == clazz && 
-		a.getAttribute(ATTR_MAIN_TYPE_NAME, "X") == project &&
+		a.getAttribute(ATTR_PROJECT_NAME, "X") == project &&
 		a.getAttribute(ATTR_PROGRAM_ARGUMENTS, "X").contains(task) && 
 		a.type.identifier == "org.xtext.builddsl.ui.BuildLaunchConfigurationType"
 	}


### PR DESCRIPTION
If the projectname differs from the main-type-name a new launchconfiguration was created on each program execution / debug.

Steps to reproduce:
1. Start a Eclipse-Instance
2. Create a new plugin-project, name it e.g. buildDSLTest
3. Create a new file in the src-folder, name it e.g. test.build, and add a valid build-DSL to it e.g. task myTask {var x = true; }
4. hit run or debug
5. a new launchconfiguration is created with the name of the file, e.g. test
6. hit run or debug again
7. a new launchconfiguration is created again e.g. test (1)